### PR TITLE
PHP7 compatibility

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -8,9 +8,7 @@
  */
 
 // must be run within Dokuwiki
-if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'syntax.php');
+if(!defined('DOKU_INC')) die();
 
 /**
  * All DokuWiki plugins to extend the parser/rendering mechanism

--- a/syntax.php
+++ b/syntax.php
@@ -17,43 +17,33 @@ require_once(DOKU_PLUGIN.'syntax.php');
  * need to inherit from this class
  */
 class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
- 
-	function getInfo(){
-		return array(
-			'author' => 'Sergio Merino',
-			'email'  => 'sergio.merino@thecorpora.com',
-			'date'   => '2011-11-24',
-			'name'   => 'Configurable Search Form Plugin',
-			'desc'   => 'Inserts a configurable search form in any page',
-			'url'    => 'http://www.dokuwiki.org/plugin:confsearch',
-		);
-    }
- 
-    function getType() { return 'substition'; }
-    function getSort() { return 138; }
 
-    function connectTo($mode) {
+    public function getType() { return 'substition'; }
+
+    public function getSort() { return 138; }
+
+    public function connectTo($mode) {
 		$this->Lexer->addSpecialPattern('\{confsearch[^\}]*\}',$mode,'plugin_confsearch');
     }
 
-    function getLastCrumb()
+    protected function getLastCrumb()
     {
-	$br = breadcrumbs();
-	$lastcrumb = '';
-	foreach ($br as $a=>$b) $lastcrumb=$a;
-	return $lastcrumb;
+	    $br = breadcrumbs();
+	    $lastcrumb = '';
+	    foreach ($br as $a=>$b) $lastcrumb=$a;
+	    return $lastcrumb;
     }
 
-    function getBaseNs($id)
+    public function getBaseNs($id)
     {
-	return getNS(cleanID($id));
+	    return getNS(cleanID($id));
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
     	return array($match, $state, $pos);
     }
 
-    function buttonname($data) {
+    protected function buttonname($data) {
         $params=trim($data[0]," \{\}");
         list($pluginname,$parameters,$button)=explode('>',$params,3);
         $replacedparams = str_replace(array(
@@ -69,7 +59,7 @@ class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
         return $replacedparams;
     }
 
-    function processparameters($data) {
+    protected function processparameters($data) {
         $params=trim($data[0]," \{\}");
         list($pluginname,$parameters,$button)=explode('>',$params,3);
         $replacedparams = str_replace(array(
@@ -83,7 +73,7 @@ class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
         return $replacedparams;
     }
 
-    function render($mode, Doku_Renderer $renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
 
  		global $lang;
 

--- a/syntax.php
+++ b/syntax.php
@@ -103,9 +103,6 @@ class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
 			$renderer->doc .= '</div>'."\n";
 			return true;
 		}
-		else{
-			$renderer->doc .= 'Hola';
-		}
 		return false;
 	}
 }

--- a/syntax.php
+++ b/syntax.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Plugin Search Form: Inserts a search form in any page
- * 
+ *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Sergio Merino <sergio.merino@thecorpora.com>
  * @code based on the plugin searchform from Adolfo González Blázquez
  */
- 
+
 // must be run within Dokuwiki
 if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');
 if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
 require_once(DOKU_PLUGIN.'syntax.php');
- 
+
 /**
  * All DokuWiki plugins to extend the parser/rendering mechanism
  * need to inherit from this class
@@ -31,11 +31,11 @@ class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
  
     function getType() { return 'substition'; }
     function getSort() { return 138; }
-    
+
     function connectTo($mode) {
 		$this->Lexer->addSpecialPattern('\{confsearch[^\}]*\}',$mode,'plugin_confsearch');
     }
-    
+
     function getLastCrumb()
     {
 	$br = breadcrumbs();
@@ -43,16 +43,16 @@ class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
 	foreach ($br as $a=>$b) $lastcrumb=$a;
 	return $lastcrumb;
     }
-    
+
     function getBaseNs($id)
     {
 	return getNS(cleanID($id));
     }
-    
-    function handle($match, $state, $pos, Doku_Handler $handler) {  
+
+    function handle($match, $state, $pos, Doku_Handler $handler) {
     	return array($match, $state, $pos);
     }
-    
+
     function buttonname($data) {
         $params=trim($data[0]," \{\}");
         list($pluginname,$parameters,$button)=explode('>',$params,3);
@@ -63,12 +63,12 @@ class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
             array(
                 $this->getBaseNs($this->getLastCrumb()),
                 $_SERVER['REMOTE_USER'],
-                ), $button); 
+                ), $button);
         if ($replacedparams=="")
         	$replacedparams="Search";
         return $replacedparams;
     }
-        
+
     function processparameters($data) {
         $params=trim($data[0]," \{\}");
         list($pluginname,$parameters,$button)=explode('>',$params,3);
@@ -79,15 +79,15 @@ class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
             array(
                 $this->getBaseNs($this->getLastCrumb()),
                 $_SERVER['REMOTE_USER'],
-                ), $parameters);  
+                ), $parameters);
         return $replacedparams;
     }
-    
+
     function render($mode, Doku_Renderer $renderer, $data) {
- 		
+
  		global $lang;
- 		
- 		
+
+
 		if ($mode == 'xhtml') {
 
 			$renderer->doc .= '<div id="searchform_plugin">'."\n";
@@ -97,7 +97,7 @@ class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
 //Debug line			$renderer->doc .= 'Debug--'.$this->processparameters($data);
                         $renderer->doc .= '<input type="text" id="qsearch2__in" accesskey="f" name="id" class="edit" autocomplete="off">'."\n";
                         $renderer->doc .= '<input type="submit" value="'.$this->buttonname($data).'" class="button" title="Search App" onclick= "document.ns_search.id.value= document.ns_search.id.value+\' \'+document.ns_search.ns.value" />'."\n";
-		
+
                         $renderer->doc .= '<div id="qsearch2__out" class="ajax_qsearch JSpopup"></div>'."\n";
 			$renderer->doc .= '</div></form>'."\n";
 			$renderer->doc .= '</div>'."\n";

--- a/syntax.php
+++ b/syntax.php
@@ -55,7 +55,7 @@ class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
     
     function buttonname($data) {
         $params=trim($data[0]," \{\}");
-        list($pluginname,$parameters,$button)=split(">",$params,3);
+        list($pluginname,$parameters,$button)=explode('>',$params,3);
         $replacedparams = str_replace(array(
                 '@NS@',
                 '@USER@',
@@ -71,7 +71,7 @@ class syntax_plugin_confsearch extends DokuWiki_Syntax_Plugin {
         
     function processparameters($data) {
         $params=trim($data[0]," \{\}");
-        list($pluginname,$parameters,$button)=split(">",$params,3);
+        list($pluginname,$parameters,$button)=explode('>',$params,3);
         $replacedparams = str_replace(array(
                 '@NS@',
                 '@USER@',


### PR DESCRIPTION
There was a fatal error when used with PHP7, because the `split` function has been removed. This PR replaces it and makes some other improvements for PHP7.

The output `hola` for non-xhtml renderers has been removed, because it is considered a stray debug statement and it caused problems with other plugins.